### PR TITLE
Improve typing of Jest config object

### DIFF
--- a/ts/ts-jest.config.cjs
+++ b/ts/ts-jest.config.cjs
@@ -1,4 +1,4 @@
-/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+/** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   extensionsToTreatAsEsm: [".ts"],
   transform: {


### PR DESCRIPTION
Since v29 configuration of `ts-jest` was moved to `transform`. Typings were reworked as well and now `JestConfigWithTsJest` must be used to have the correct types. See: https://kulshekhar.github.io/ts-jest/docs/getting-started/options